### PR TITLE
fix: try to make reading close calls race-safe

### DIFF
--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/NonBlockingLineReader.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/NonBlockingLineReader.java
@@ -182,7 +182,10 @@ final class NonBlockingLineReader implements Closeable {
    */
   @Override
   public void close() throws IOException {
-    this.reader.close();
-    this.reader = null;
+    var reader = this.reader;
+    if (reader != null) {
+      this.reader = null;
+      reader.close();
+    }
   }
 }

--- a/node/impl/src/test/java/eu/cloudnetservice/node/impl/service/defaults/log/NonBlockingLineReaderTest.java
+++ b/node/impl/src/test/java/eu/cloudnetservice/node/impl/service/defaults/log/NonBlockingLineReaderTest.java
@@ -48,6 +48,15 @@ public class NonBlockingLineReaderTest {
   }
 
   @Test
+  void testClosingReaderIsIdempotent() {
+    var source = new StringReader("Hello\nWorld");
+    var reader = new NonBlockingLineReader(source);
+
+    Assertions.assertDoesNotThrow(reader::close);
+    Assertions.assertDoesNotThrow(reader::close);
+  }
+
+  @Test
   void testMultipleNewlinesAreParsedCorrectly() throws IOException {
     var source = new StringReader("Hello\n\nWorld\n");
     var reader = new NonBlockingLineReader(source);


### PR DESCRIPTION
### Motivation
Issue #1855 describes that most likely there is a race between different stop calls that result in an exception when trying to close the already closed reader.

### Modification
Added an additional null-check that makes sure that the reader is not getting closed multiple times

### Result
Hopefully no issues anymore

##### Other context
Fixes #1855
